### PR TITLE
I made a small change to the compile_support.rb...

### DIFF
--- a/lib/prawnto/template_handler/compile_support.rb
+++ b/lib/prawnto/template_handler/compile_support.rb
@@ -31,7 +31,7 @@ module Prawnto
 
       # added to make ie happy with ssl pdf's (per naisayer)
       def ssl_request?
-        @controller.request.env['SERVER_PROTOCOL'].downcase == "https"
+        !@controller.request.env['SERVER_PROTOCOL'].blank? && @controller.request.env['SERVER_PROTOCOL'].downcase == "https"
       end
       memoize :ssl_request?
 


### PR DESCRIPTION
I made a small change to the compile_support.rb file to check for a nil case for env["SERVER_PROTOCOL"] as it was causing a problem when I moved my project to jRuby running inside jBoss.  

Thanks for all the great work on prawnto, it makes my code a lot cleaner!

Jeff
