### PR TITLE
Rails 3 deprecation fixes

### DIFF
--- a/lib/prawnto/template_handlers/base.rb
+++ b/lib/prawnto/template_handlers/base.rb
@@ -1,9 +1,8 @@
 module Prawnto
   module TemplateHandlers
-    class Base < ::ActionView::TemplateHandler
-      include ::ActionView::TemplateHandlers::Compilable
-      
-      def compile(template)
+    class Base
+
+      def self.call(template)
         "_prawnto_compile_setup;" +
         "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" + 
         "#{template.source}\n" +

--- a/lib/prawnto/template_handlers/dsl.rb
+++ b/lib/prawnto/template_handlers/dsl.rb
@@ -2,7 +2,7 @@ module Prawnto
   module TemplateHandlers
     class Dsl < Base
       
-      def compile(template)
+      def self.call(template)
         "_prawnto_compile_setup(true);" +
         "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" + 
         "pdf.instance_eval do; #{template.source}\nend;" +

--- a/lib/prawnto/template_handlers/raw.rb
+++ b/lib/prawnto/template_handlers/raw.rb
@@ -2,7 +2,7 @@ module Prawnto
   module TemplateHandlers
     class Raw < Base
       
-      def compile(template)
+      def self.call(template)
         #TODO: what's up with filename here?  not used is it?
         source,filename = massage_template_source(template)
         "_prawnto_compile_setup;" +


### PR DESCRIPTION
As Rails3 code says: Inheriting from ActionView::Template::Handler is deprecated. Since Rails 3, all the API your template handler needs to implement is to respond to #call.
This pull request fixes this issue (small code change)
