### PR TITLE
Fix pdf mime type warning

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -3,5 +3,9 @@ require 'prawnto'
 Mime::Type.register "application/pdf", :pdf
 ActionView::Template.register_template_handler 'prawn', Prawnto::TemplateHandlers::Base
 ActionView::Template.register_template_handler 'prawn_dsl', Prawnto::TemplateHandlers::Dsl
-ActionView::Template.register_template_handler 'prawn_xxx', Prawnto::TemplateHandlers::Raw  
+ActionView::Template.register_template_handler 'prawn_xxx', Prawnto::TemplateHandlers::Raw
 
+# Bit of a hack to enable ActionMailer to us pdf.prawn templates to generate attachments
+if defined?(ActionMailer) && defined?(ActionMailer::Base)
+  ActionMailer::Base.send(:include, Prawnto::ActionController)
+end

--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require 'prawnto'
 
-Mime::Type.register "application/pdf", :pdf
+Mime::Type.register "application/pdf", :pdf unless Mime::PDF
 ActionView::Template.register_template_handler 'prawn', Prawnto::TemplateHandlers::Base
 ActionView::Template.register_template_handler 'prawn_dsl', Prawnto::TemplateHandlers::Dsl
 ActionView::Template.register_template_handler 'prawn_xxx', Prawnto::TemplateHandlers::Raw

--- a/lib/prawnto/action_controller.rb
+++ b/lib/prawnto/action_controller.rb
@@ -2,18 +2,18 @@ module Prawnto
   module ActionController
 
     DEFAULT_PRAWNTO_OPTIONS = {:inline=>true}
-      
-    def self.included(base)
-      base.extend ClassMethods
+    extend ActiveSupport::Concern
+
+    included do
+      self.class_attribute :prawnto_options
+      self.class_attribute :prawn_options
     end
 
     module ClassMethods
       def prawnto(options)
-        prawn_options, prawnto_options = breakdown_prawnto_options options
-        write_inheritable_hash(:prawn, prawn_options)
-        write_inheritable_hash(:prawnto, prawnto_options)
+        self.prawn_options, self.prawnto_options = breakdown_prawnto_options options
       end
-    
+
     private
 
       def breakdown_prawnto_options(options)
@@ -23,20 +23,22 @@ module Prawnto
       end
     end
 
-    def prawnto(options)
-      @prawnto_options ||= DEFAULT_PRAWNTO_OPTIONS.dup
-      @prawnto_options.merge! options
-    end
+    module InstanceMethods
+      def prawnto(options)
+        @prawnto_options ||= DEFAULT_PRAWNTO_OPTIONS.dup
+        @prawnto_options.merge! options
+      end
 
 
-  private
+    private
 
-    def compute_prawnto_options
-      @prawnto_options ||= DEFAULT_PRAWNTO_OPTIONS.dup
-      @prawnto_options[:prawn] ||= {}
-      @prawnto_options[:prawn].merge!(self.class.read_inheritable_attribute(:prawn) || {}) {|k,o,n| o}
-      @prawnto_options.merge!(self.class.read_inheritable_attribute(:prawnto) || {}) {|k,o,n| o}
-      @prawnto_options
+      def compute_prawnto_options
+        @prawnto_options ||= DEFAULT_PRAWNTO_OPTIONS.dup
+        @prawnto_options[:prawn] ||= {}
+        @prawnto_options[:prawn].merge!(prawn_options || {}) {|k,o,n| o}
+        @prawnto_options.merge!(prawnto_options|| {}) {|k,o,n| o}
+        @prawnto_options
+      end
     end
 
   end

--- a/lib/prawnto/template_handler/compile_support.rb
+++ b/lib/prawnto/template_handler/compile_support.rb
@@ -33,7 +33,7 @@ module Prawnto
 
       # added to make ie happy with ssl pdf's (per naisayer)
       def ssl_request?
-        @controller.request.env['SERVER_PROTOCOL'].downcase == "https"
+        @controller.request.ssl?
       end
       memoize :ssl_request?
 

--- a/lib/prawnto/template_handler/compile_support.rb
+++ b/lib/prawnto/template_handler/compile_support.rb
@@ -3,7 +3,7 @@ module Prawnto
 
     class CompileSupport
       extend ActiveSupport::Memoizable
-      
+
       attr_reader :options
 
       def initialize(controller)
@@ -17,10 +17,12 @@ module Prawnto
       end
 
       def set_headers
-        set_pragma
-        set_cache_control
-        set_content_type
-        set_disposition
+        unless defined?(ActionMailer) && defined?(ActionMailer::Base) && @controller.is_a?(ActionMailer::Base)
+          set_pragma
+          set_cache_control
+          set_content_type
+          set_disposition
+        end
       end
 
       # TODO: kept around from railspdf-- maybe not needed anymore? should check.
@@ -67,6 +69,5 @@ module Prawnto
 
   end
 end
-
 
 

--- a/lib/prawnto/template_handlers/base.rb
+++ b/lib/prawnto/template_handlers/base.rb
@@ -1,9 +1,7 @@
 module Prawnto
   module TemplateHandlers
-    class Base < ::ActionView::TemplateHandler
-      include ::ActionView::TemplateHandlers::Compilable
-      
-      def compile(template)
+    class Base
+      def call(template)
         "_prawnto_compile_setup;" +
         "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" + 
         "#{template.source}\n" +

--- a/lib/prawnto/template_handlers/base.rb
+++ b/lib/prawnto/template_handlers/base.rb
@@ -1,9 +1,13 @@
 module Prawnto
   module TemplateHandlers
     class Base
+      def self.call(template)
+        new.call(template)
+      end
+
       def call(template)
         "_prawnto_compile_setup;" +
-        "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" + 
+        "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" +
         "#{template.source}\n" +
         "raw pdf.render;"
       end

--- a/lib/prawnto/template_handlers/base.rb
+++ b/lib/prawnto/template_handlers/base.rb
@@ -7,7 +7,7 @@ module Prawnto
         "_prawnto_compile_setup;" +
         "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" + 
         "#{template.source}\n" +
-        "pdf.render;"
+        "raw pdf.render;"
       end
     end
   end

--- a/lib/prawnto/template_handlers/dsl.rb
+++ b/lib/prawnto/template_handlers/dsl.rb
@@ -2,7 +2,7 @@ module Prawnto
   module TemplateHandlers
     class Dsl < Base
       
-      def compile(template)
+      def call(template)
         "_prawnto_compile_setup(true);" +
         "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" + 
         "pdf.instance_eval do; #{template.source}\nend;" +

--- a/lib/prawnto/template_handlers/dsl.rb
+++ b/lib/prawnto/template_handlers/dsl.rb
@@ -6,7 +6,7 @@ module Prawnto
         "_prawnto_compile_setup(true);" +
         "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" + 
         "pdf.instance_eval do; #{template.source}\nend;" +
-        "pdf.render;"
+        "raw pdf.render;"
       end
 
     end

--- a/lib/prawnto/template_handlers/raw.rb
+++ b/lib/prawnto/template_handlers/raw.rb
@@ -2,7 +2,7 @@ module Prawnto
   module TemplateHandlers
     class Raw < Base
       
-      def compile(template)
+      def call(template)
         #TODO: what's up with filename here?  not used is it?
         source,filename = massage_template_source(template)
         "_prawnto_compile_setup;" +

--- a/tasks/prawnto_tasks.rake
+++ b/tasks/prawnto_tasks.rake
@@ -1,4 +1,0 @@
-# desc "Explaining what the task does"
-# task :prawnto do
-#   # Task goes here
-# end


### PR DESCRIPTION
This stops the following warning happening while rails initializes

```
warning: already initialized constant PDF
```

I think this is happens because action dispatch sets up the mime type by default https://github.com/rails/rails/blob/e20dd73df42d63b206d221e2258cc6dc7b1e6068/actionpack/lib/action_dispatch/http/mime_types.rb#L31

The fix just stops the constant defined if it is already present
